### PR TITLE
Add config manager

### DIFF
--- a/backend/authn/BUILD.bazel
+++ b/backend/authn/BUILD.bazel
@@ -13,6 +13,7 @@ java_library(
         "@vertx//:io_vertx_vertx_rx_java2",
         "@vertx//:io_vertx_vertx_web",
         "@vertx//:io_vertx_vertx_web_client",
+        "@vertx//:org_apache_commons_commons_lang3",
     ],
 )
 

--- a/backend/authn/src/main/java/com/micifuz/authn/MainVerticle.java
+++ b/backend/authn/src/main/java/com/micifuz/authn/MainVerticle.java
@@ -1,36 +1,41 @@
 package com.micifuz.authn;
 
+import java.util.Arrays;
+
+import com.micifuz.authn.configuration.ConfigManager;
 import com.micifuz.authn.ioc.IoC;
+
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.reactivex.core.AbstractVerticle;
-import io.vertx.reactivex.core.http.HttpServer;
 import io.vertx.reactivex.ext.web.Router;
-
-import java.util.Arrays;
 
 public class MainVerticle extends AbstractVerticle {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(MainVerticle.class.getName());
-	private final String HOST = "0.0.0.0";
-	private final Integer PORT = 8080;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MainVerticle.class.getName());
+    private final String HOST = "0.0.0.0";
+    private final Integer PORT = 8080;
 
-	@Override
-	public Completable rxStart() {
-		vertx.exceptionHandler(error -> LOGGER.info(
-			error.getMessage() + error.getCause() + Arrays.toString(error.getStackTrace()) + error
-				.getLocalizedMessage()));
+    @Override
+    public Completable rxStart() {
+        vertx.exceptionHandler(error -> LOGGER.info(
+                error.getMessage() + error.getCause() + Arrays.toString(error.getStackTrace()) + error
+                        .getLocalizedMessage()));
 
-		return IoC.getInstance().getRouting().createRouter().flatMap(this::startHttpServer)
-			.flatMapCompletable(httpServer -> {
-				LOGGER.info(String.format("HTTP server started on http://%s:%d", HOST, PORT));
-				return Completable.complete();
-			});
-	}
+        Single<Integer> serverPort = ConfigManager.getInstance(vertx).resolveProperty("server.port", PORT);
+        Single<Router> serverRouter = IoC.getInstance().getRouting().createRouter();
 
-	private Single<HttpServer> startHttpServer(Router router) {
-		return vertx.createHttpServer().requestHandler(router).rxListen(PORT, HOST);
-	}
+        return serverRouter.zipWith(serverPort, this::startHttpServer)
+                .doOnError(LOGGER::error)
+                .flatMapCompletable(started -> started);
+    }
+
+    private Completable startHttpServer(Router router, Integer port) {
+        return vertx.createHttpServer().requestHandler(router).rxListen(port, HOST).flatMapCompletable(httpServer -> {
+            LOGGER.info(String.format("HTTP server started on http://%s:%d", HOST, port));
+            return Completable.complete();
+        });
+    }
 }

--- a/backend/authn/src/main/java/com/micifuz/authn/configuration/ConfigManager.java
+++ b/backend/authn/src/main/java/com/micifuz/authn/configuration/ConfigManager.java
@@ -1,0 +1,128 @@
+package com.micifuz.authn.configuration;
+
+import org.apache.commons.lang3.StringUtils;
+
+import io.reactivex.Single;
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.config.ConfigRetriever;
+import io.vertx.reactivex.core.Vertx;
+
+public class ConfigManager {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConfigManager.class.getName());
+
+    private static final String ENV_SEPARATOR = "_";
+    private static final String ENV_PREFIX = "X";
+    private static final String DEFAULT_CONFIG_PATH = "config.yaml";
+    private static ConfigManager instance = null;
+
+    private final Single<JsonObject> config;
+
+    private enum FileType {JSON, YAML}
+
+    public static synchronized ConfigManager getInstance(Vertx vertx) {
+        if (instance == null) {
+            instance = new ConfigManager(vertx);
+        }
+        return instance;
+    }
+
+    private ConfigManager(Vertx vertx) {
+        ConfigRetrieverOptions opt = new ConfigRetrieverOptions().addStore(getConfigStoreOpt(FileType.YAML));
+        ConfigRetriever configRetriever = ConfigRetriever.create(vertx, opt);
+        config = configRetriever.rxGetConfig();
+    }
+
+    public Single<Boolean> resolveProperty(String query, Boolean defaultValue) {
+        String value = System.getenv(toEnvironmentVariableName(query));
+        if (StringUtils.isBlank(value)) {
+            return config.map(config -> {
+                if (!isLeaf(query)) {
+                    JsonObject leaf = getLeaf(query, config);
+                    return leaf.getBoolean(getLeafPropertyName(query), defaultValue);
+                }
+                return config.getBoolean(query, defaultValue);
+            });
+        }
+
+        return Single.just(Boolean.parseBoolean(value));
+    }
+
+    public Single<String> resolveProperty(String query, String defaultValue) {
+        String value = System.getenv(toEnvironmentVariableName(query));
+        if (StringUtils.isBlank(value)) {
+            return config.map(config -> {
+                if (!isLeaf(query)) {
+                    JsonObject leaf = getLeaf(query, config);
+                    return leaf.getString(getLeafPropertyName(query), defaultValue);
+                }
+                return config.getString(query, defaultValue);
+            });
+        }
+
+        return Single.just(value);
+    }
+
+    public Single<Integer> resolveProperty(String query, int defaultValue) {
+        String value = System.getenv(toEnvironmentVariableName(query));
+        if (StringUtils.isBlank(value)) {
+            return config.map(config -> {
+                if (!isLeaf(query)) {
+                    JsonObject leaf = getLeaf(query, config);
+                    return leaf.getInteger(getLeafPropertyName(query), defaultValue);
+                }
+                return config.getInteger(query, defaultValue);
+            });
+        }
+
+        return Single.just(Integer.parseInt(value));
+    }
+
+    public Single<JsonObject> getConfig() {
+        return config;
+    }
+
+    private String toEnvironmentVariableName(String name) {
+        return ENV_PREFIX + ENV_SEPARATOR + name.replace(".", ENV_SEPARATOR).toUpperCase();
+    }
+
+    private ConfigStoreOptions getConfigStoreOpt(FileType type) {
+        return new ConfigStoreOptions()
+                .setType("file")
+                .setFormat(type.name().toLowerCase())
+                .setConfig(new JsonObject().put("path", getConfigPath()));
+    }
+
+    private String getConfigPath() {
+        String configPath = System.getenv("VERTX_CONFIG_PATH");
+        if (StringUtils.isBlank(configPath)) {
+            LOG.warn("Missing VERTX_CONFIG_PATH environment variable. Set config default path to config.yaml");
+            configPath = DEFAULT_CONFIG_PATH;
+        }
+        return configPath;
+    }
+
+    private boolean isLeaf(String query) {
+        return !query.contains(".");
+    }
+
+    private String getLeafPropertyName(String query) {
+        String[] queryNames = query.split("\\.");
+        return queryNames[queryNames.length - 1];
+    }
+
+    private JsonObject getLeaf(String query, JsonObject config) {
+        String[] queryNames = query.split("\\.");
+        JsonObject leaf = config.getJsonObject(queryNames[0]);
+
+        for (int i = 1; i < queryNames.length - 1; i++) {
+            leaf = config.getJsonObject(queryNames[i]);
+        }
+
+        return leaf;
+    }
+}

--- a/backend/authn/src/main/java/com/micifuz/authn/ioc/IoC.java
+++ b/backend/authn/src/main/java/com/micifuz/authn/ioc/IoC.java
@@ -21,7 +21,7 @@ public class IoC {
         return instance;
     }
 
-    public IoC() {
+    private IoC() {
         routing = new Routing();
         Vertx vertx = Vertx.currentContext().owner();
         Procedures healthCheckProcedures = new Procedures(vertx);

--- a/backend/authn/src/main/resources/config.yaml
+++ b/backend/authn/src/main/resources/config.yaml
@@ -1,0 +1,2 @@
+server:
+  port: 8080

--- a/maven.bzl
+++ b/maven.bzl
@@ -11,6 +11,7 @@ HTTP_CLIENT_VERSION = "4.5.13"
 REST_ASSURE_VERSION = "4.4.0"
 MOCKITO_VERSION = "3.12.4"
 HAMCREST_VERSION = "1.3"
+COMMONS_LANGS3_VERSION = "3.12.0"
 
 def maven():
     maven_install(
@@ -25,6 +26,7 @@ def maven():
             "io.vertx:vertx-config:%s" % VERTX_VERSION,
             "io.vertx:vertx-config-yaml:%s" % VERTX_VERSION,
             "io.netty:netty-transport:%s" % NETTY_TRANSPORT_VERSION,
+            "org.apache.commons:commons-lang3:%s" % COMMONS_LANGS3_VERSION,
         ],
         repositories = [
             "https://repo1.maven.org/maven2",


### PR DESCRIPTION
Add config manager in order to read config files. 

- Currently, we only support Yaml files due to a "limitation" (a lack of design) of the config manager. 
- We have added some commodity methods as `resolveProperty` that will handler "complex" queries as retrieve a property leaf. 

